### PR TITLE
fix: simplify root_dir handling

### DIFF
--- a/lua/codesettings/util.lua
+++ b/lua/codesettings/util.lua
@@ -28,9 +28,8 @@ function M.fqn(fname)
 end
 
 ---Get root directory based on root markers
----@param fname string?
 ---@return string?
-function M.get_root(fname)
+function M.get_root()
   local user_root = Config.root_dir
   if type(user_root) == 'string' then
     return user_root
@@ -47,7 +46,7 @@ function M.get_root(fname)
     :totable()
   table.insert(root_patterns, '.git')
   table.insert(root_patterns, '.jj')
-  return vim.fs.root(fname or vim.env.PWD or vim.uv.cwd(), root_patterns)
+  return vim.fs.root(0, root_patterns)
 end
 
 ---@class GetlocalConfigsOpts


### PR DESCRIPTION
This change ensures that the root directory search starts from the edited file, instead of the current working directory.

See https://github.com/mrjones2014/codesettings.nvim/discussions/35 for more details. I hope removing the `fname` argument is OK.