### PR TITLE
feat(integrations): Lua_ls integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ return {
     config_file_paths = { '.vscode/settings.json', 'codesettings.json', 'lspsettings.json' },
     ---Integrate with jsonls to provide LSP completion for LSP settings based on schemas
     jsonls_integration = true,
+    ---Set up library paths for lua_ls automatically to pick up the generated type
+    ---annotations provided by codesettings.nvim; to enable for only your nvim config,
+    ---you can also do something like:
+    ---lua_ls_integration = function()
+    ---  return vim.uv.cwd() == ('%s/.config/nvim'):format(vim.env.HOME)
+    ---end,
+    lua_ls_integration = true,
     ---Set filetype to jsonc when opening a file specified by `config_file_paths`,
     ---make sure you have the jsonc tree-sitter parser installed for highlighting
     jsonc_filetype = true,
@@ -44,8 +51,8 @@ return {
     },
   },
   -- I recommend loading on these filetype so that the
-  -- jsonls integration and jsonc filetype setup works
-  ft = { 'json', 'jsonc' },
+  -- jsonls integration, lua_ls integration, and jsonc filetype setup works
+  ft = { 'json', 'jsonc', 'lua' },
 }
 ```
 
@@ -136,8 +143,8 @@ return {
 - `jsonc` filetype for local config files
 - `jsonls` integration for schema-based completion of LSP settings in JSON(C) configuration files
   ![jsonls integration](https://github.com/user-attachments/assets/5d37f0bb-0e07-4c22-bc6b-16cf3e65e201)
-- Lua type annotations generated from schemas for autocomplete when writing LSP configs in Lua
-  ![lua type annotations](https://github.com/user-attachments/assets/f57d938f-3f9b-4c9c-9acd-1fb5996fb8d1)
+- Lua type annotations generated from schemas for autocomplete when writing LSP configs in Lua, with optional `lua_ls` integration
+  ![lua type annotations](https://github.com/user-attachments/assets/86d85ff3-1467-4c0b-9542-02cc831951dc)
 - Supports custom config file names/locations
 - Supports mixed nested and dotted key paths, for example, this project's `codesettings.json` looks like:
 
@@ -154,13 +161,15 @@ return {
 }
 ```
 
-To get autocomplete in Lua files:
+To get autocomplete in Lua files, either set `config.lua_ls_integration = true`, or use `---@module 'codesettings'` which will tell `lua_ls` as though `codesettings`
+has been `require`d, then you will have access to `---@type lsp.server_name` generated type annotations.
 
 ```lua
 -- for example, for lua_ls
 vim.lsp.config('lua_ls', {
   -- this '@module' annotation makes lua_ls import the library from codesettings,
-  -- where the annotations come from
+  -- where the annotations come from; this isn't needed if you use `lua_ls_integration = true`
+  -- and `codesettings.nvim` is loaded
   ---@module 'codesettings'
   -- then you will have access to the generated type annotations
   ---@type lsp.lua_ls
@@ -324,4 +333,3 @@ This project would not exist without the hard work of some other open source pro
 - [x] [yamlls](https://github.com/redhat-developer/vscode-yaml/tree/master/package.json)
 - [x] [zeta_note](https://github.com/artempyanykh/zeta-note-vscode/tree/main/package.json)
 - [x] [zls](https://github.com/zigtools/zls-vscode/tree/master/package.json)
-

--- a/lua/codesettings/config.lua
+++ b/lua/codesettings/config.lua
@@ -1,6 +1,7 @@
 ---@class CodesettingsConfig
 ---@field config_file_paths string[] List of config file paths to look for
 ---@field jsonls_integration boolean Integrate with jsonls for LSP settings completion
+---@field lua_ls_integration boolean|fun():boolean Integrate with lua_ls for LSP settings completion; can be a function so that, for example, you can enable it only if editing your nvim config
 ---@field jsonc_filetype boolean Set filetype to jsonc for config files
 ---@field default_merge_opts CodesettingsMergeOpts Default options for merging settings
 ---@field root_dir (string|fun():string)? Function or string to determine the project root directory; defaults to `require('codesettings.util').get_root()`
@@ -9,6 +10,7 @@
 local options = {
   config_file_paths = { '.vscode/settings.json', 'codesettings.json', 'lspsettings.json' },
   jsonls_integration = true,
+  lua_ls_integration = true,
   jsonc_filetype = true,
   root_dir = nil, -- use the default root finder
   default_merge_opts = {
@@ -31,6 +33,11 @@ function Config.setup(opts)
 
   if options.jsonc_filetype then
     require('codesettings.integrations.jsonc-filetype').setup()
+  end
+
+  local lua_ls_integration = options.lua_ls_integration
+  if lua_ls_integration == true or (type(lua_ls_integration) == 'function' and lua_ls_integration()) then
+    require('codesettings.integrations.lua_ls').setup()
   end
 end
 

--- a/lua/codesettings/integrations/jsonls/init.lua
+++ b/lua/codesettings/integrations/jsonls/init.lua
@@ -68,14 +68,7 @@ function M.setup()
   })
 
   -- lazy loading; if jsonls is already active, restart it
-  vim.defer_fn(function()
-    if #vim.lsp.get_clients({ name = 'jsonls' }) > 0 then
-      vim.lsp.enable('jsonls', false)
-      vim.defer_fn(function()
-        vim.lsp.enable('jsonls')
-      end, 500)
-    end
-  end, 500)
+  Util.restart_lsp('jsonls')
 end
 
 return M

--- a/lua/codesettings/integrations/lua_ls.lua
+++ b/lua/codesettings/integrations/lua_ls.lua
@@ -1,0 +1,24 @@
+local Util = require('codesettings.util')
+
+local M = {}
+
+function M.setup()
+  ---@type lsp.lua_ls
+  local lua_ls_settings = (vim.lsp.config.lua_ls or {}).settings or {}
+  local library = vim.tbl_get(lua_ls_settings, 'Lua', 'workspace', 'library') or {}
+  vim.list_extend(library, { Util.path('lua/codesettings/generated') })
+  vim.lsp.config('lua_ls', {
+    settings = {
+      Lua = {
+        workspace = {
+          library = library,
+        },
+      },
+    },
+  })
+
+  -- lazy loading; if lua_ls is already active, restart it
+  Util.restart_lsp('lua_ls')
+end
+
+return M

--- a/lua/codesettings/util.lua
+++ b/lua/codesettings/util.lua
@@ -212,4 +212,15 @@ function M.error(msg, ...)
   vim.notify(('%s%s'):format(msg_prefix, msg:format(...)), vim.log.levels.ERROR)
 end
 
+function M.restart_lsp(name)
+  vim.defer_fn(function()
+    if #vim.lsp.get_clients({ name = name }) > 0 then
+      vim.lsp.enable(name, false)
+      vim.defer_fn(function()
+        vim.lsp.enable(name)
+      end, 500)
+    end
+  end, 500)
+end
+
 return M


### PR DESCRIPTION
Adds an optional `lua_ls` integration so that you don't have to use `---@module 'codesettings'` to get the generated type annotations onto your `lua_ls` library path. 