### PR TITLE
fix(config): Map custom type aliases to `table` for builder validation

### DIFF
--- a/lua/codesettings/config/builder.lua
+++ b/lua/codesettings/config/builder.lua
@@ -32,6 +32,10 @@ local builder_mt = {
               table.insert(val_types, 'function')
             elseif t == 'null' then
               table.insert(val_types, 'nil')
+            elseif type(t) == 'string' and t:match('^%u') then
+              -- Custom type name (starts with uppercase) - map to 'table'
+              -- Examples: 'CodesettingsLoaderExtension', 'CodesettingsMergeListsBehavior'
+              table.insert(val_types, 'table')
             else
               table.insert(val_types, t)
             end

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -132,5 +132,16 @@ describe('codesettings.config', function()
         builder:root_dir(123) ---@diagnostic disable-line: param-type-mismatch
       end)
     end)
+
+    it('sets loader_extensions correctly', function()
+      -- test loading by module path
+      local exts = { 'my.extension', 'another.extension' }
+      local config = ConfigBuilder.new():loader_extensions(exts):build()
+      assert.same(exts, config.loader_extensions)
+
+      -- test loading  by inline extension instances
+      local config2 = ConfigBuilder.new():loader_extensions({ require('codesettings.extensions.env') }):build()
+      assert.is_table(config2.loader_extensions)
+    end)
   end)
 end)


### PR DESCRIPTION
Fixes #80 