### PR TITLE
feat: use custom filetype for output panel

### DIFF
--- a/lua/codesettings/commands/view.lua
+++ b/lua/codesettings/commands/view.lua
@@ -30,7 +30,7 @@ function M.show(str)
   opts.col = (vim.o.columns - opts.width) / 2
 
   local buf_scope = { buf = buf }
-  vim.api.nvim_set_option_value('filetype', 'markdown', buf_scope)
+  vim.api.nvim_set_option_value('filetype', 'codesettings-output', buf_scope)
   vim.api.nvim_set_option_value('bufhidden', 'wipe', buf_scope)
   vim.api.nvim_set_option_value('modifiable', false, buf_scope)
 

--- a/lua/codesettings/init.lua
+++ b/lua/codesettings/init.lua
@@ -87,6 +87,8 @@ end
 ---Setup the plugin with the given options.
 ---@param opts CodesettingsConfigOverrides? optional config overrides for the global plugin configuration
 function M.setup(opts)
+  vim.treesitter.language.register('markdown', 'codesettings-output')
+
   opts = opts or {}
   require('codesettings.config').setup(opts)
 end


### PR DESCRIPTION
Makes it easier to control what LSPs attach to / plugins act upon the output panel.

Also make the output panel a scratch-buffer and set all the buffer options before opening the window.