### PR TITLE
fix(live-reload): Do not setup autocmd if there are no config files

### DIFF
--- a/lua/codesettings/init.lua
+++ b/lua/codesettings/init.lua
@@ -87,8 +87,10 @@ function M.loader()
   return require('codesettings.config.builder').new()
 end
 
+---@class (partial) CodesettingsConfigSetupInput: CodesettingsConfig
+
 ---Setup the plugin with the given options.
----@param opts CodesettingsConfigOverrides? optional config overrides for the global plugin configuration
+---@param opts CodesettingsConfigSetupInput? optional config overrides for the global plugin configuration
 function M.setup(opts)
   vim.treesitter.language.register('markdown', 'codesettings-output')
 

--- a/lua/codesettings/setup/live-reload.lua
+++ b/lua/codesettings/setup/live-reload.lua
@@ -2,6 +2,8 @@ local Util = require('codesettings.util')
 
 local M = {}
 
+M.augroup_name = 'CodesettingsLiveReload'
+
 ---@type number|nil
 local augroup = nil
 
@@ -45,8 +47,17 @@ function M.setup()
     return
   end
 
-  augroup = vim.api.nvim_create_augroup('CodesettingsLiveReload', { clear = true })
   local config_files = Util.get_local_configs({ only_exists = false })
+  if #config_files == 0 then
+    -- if there are no config files,
+    -- skip setting up the autocmd,
+    -- otherwise the empty table `{}`
+    -- pattern will match _all_ files,
+    -- and try to parse any file as a
+    -- config file
+    return
+  end
+  augroup = vim.api.nvim_create_augroup(M.augroup_name, { clear = true })
   vim.api.nvim_create_autocmd('BufWritePost', {
     group = augroup,
     pattern = config_files,

--- a/spec/integration_tests_spec.lua
+++ b/spec/integration_tests_spec.lua
@@ -189,4 +189,36 @@ describe('integration tests', function()
     -- see ./test-config-files/env_extension.json
     assert.same({ vim.env.HOME .. '/some-feature', 'base-feature' }, merged.settings['rust-analyzer'].cargo.features)
   end)
+
+  describe('live reload', function()
+    local group = require('codesettings.setup.live-reload').augroup_name
+    before_each(function()
+      pcall(vim.api.nvim_clear_autocmds, { group = group })
+      local ok, autocmds = pcall(vim.api.nvim_get_autocmds, { group = group })
+      if not ok then
+        autocmds = {}
+      end
+      assert.equal(0, #autocmds)
+    end)
+
+    it('should setup the autocmd if at least 1 local config file is found', function()
+      local Codesettings = require('codesettings')
+      spy.on(vim.api, 'nvim_create_augroup')
+      Codesettings.setup({
+        root_dir = vim.fn.getcwd() .. '/spec/test-config-files/',
+        live_reload = true,
+      })
+      assert.spy(vim.api.nvim_create_augroup --[[@as luassert.spy]]).called_with(group, { clear = true })
+    end)
+
+    it('should NOT setup the autocmd if no local config files are found', function()
+      local Codesettings = require('codesettings')
+      spy.on(vim.api, 'nvim_create_augroup')
+      Codesettings.setup({
+        root_dir = vim.fn.tempname(),
+        live_reload = true,
+      })
+      assert.spy(vim.api.nvim_create_augroup --[[@as luassert.spy]]).not_called_with(group, { clear = true })
+    end)
+  end)
 end)


### PR DESCRIPTION
Fixes #127 