### PR TITLE
fix(schema): Set `markdownDescription` on config json schema

### DIFF
--- a/lua/codesettings/config/schema.lua
+++ b/lua/codesettings/config/schema.lua
@@ -146,6 +146,7 @@ end
 ---@param prop CodesettingsSchemaValue
 ---@return table
 local function copy_and_filter_prop(prop)
+  ---@type table
   local result = vim.deepcopy(prop)
 
   -- Filter function types from the type field
@@ -163,6 +164,11 @@ local function copy_and_filter_prop(prop)
     for key, child_prop in pairs(result.properties) do
       result.properties[key] = copy_and_filter_prop(child_prop)
     end
+  end
+
+  -- make editors render the description as markdown
+  if result.description then
+    result.markdownDescription = result.description
   end
 
   -- Remove custom fields that aren't part of JSON schema


### PR DESCRIPTION
This makes the LSP hover docs render correctly when showing the hover menu in a json config file for the plugin.

i.e.

**Before:**

<img width="940" height="208" alt="image" src="https://github.com/user-attachments/assets/a4a68ec0-ea19-47c9-a710-ca84ca675c09" />


**After:**

<img width="949" height="203" alt="image" src="https://github.com/user-attachments/assets/838d908a-5e8a-4e4d-a8dd-d32617ec634f" />
